### PR TITLE
[LIB] update fork context

### DIFF
--- a/cloci/lib/hgx2hlgs.py
+++ b/cloci/lib/hgx2hlgs.py
@@ -377,7 +377,7 @@ def hlg_sim_mp_mngr(adj_mat, sim_file, max_complete, loci, hgLoci, index,
     write_proc = mp.Process(target=hlg_sim_write_mngr, args=(Q, sim_file))
     write_proc.start()
 
-    with mp.get_context('forkserver').Pool(processes = cpus - 1) as pool:
+    with mp.Pool(processes = cpus - 1) as pool:
         pool.starmap(calc_sim_by_row, tqdm(cmds, total = len(cmds)))
         pool.close()
         pool.join()
@@ -529,7 +529,7 @@ def rnd2_loc2loc_mngr(hlg_dir, loci, hg_loci,
     missing_hgs = set(blast_hash.keys()).difference(finished_hgs)
     if missing_hgs:
         blast_hash = {k: blast_hash[k] for k in list(missing_hgs)}
-        with mp.get_context('forkserver').Pool(processes = cpus) as pool:
+        with mp.Pool(processes = cpus) as pool:
             pool.starmap(rnd2_gen_blastids_mp, 
                          ((hg, group_dict, hgx_dir, hlg_dir, minid) \
                            for hg, group_dict in blast_hash.items()))
@@ -613,7 +613,7 @@ def rnd1_loc2loc_mngr(
         missing_hgs = set(blast_hash.keys()).difference(finished_hgs)
         if missing_hgs:
             blast_hash = {k: blast_hash[k] for k in list(missing_hgs)}
-            with mp.get_context('forkserver').Pool(processes = cpus) as pool:
+            with mp.Pool(processes = cpus) as pool:
                 pool.starmap(gen_blastids_mp, 
                              ((hg, genes, hgx_dir, hlg_dir, minid) \
                                for hg, genes in blast_hash.items() \
@@ -1285,7 +1285,7 @@ def lg_loc_mngr(db, lgs, gene2hg, max_between = 2, cpus = 1):
             ome = loc[0][:loc[0].find('_')]
             omes2loci[ome].append((loc, lg))
 
-    with mp.get_context('forkserver').Pool(processes = cpus) as pool:
+    with mp.Pool(processes = cpus) as pool:
         lg_loci = pool.starmap(hash_ome_lg_loc,
                                tqdm(((db[ome]['gff3'], omes2loci[ome],
                                       max_between) for ome in db.keys()), 
@@ -1362,7 +1362,7 @@ def refine_group(db, ome2i, group_hg_loci, group_loci,
                     Q.get()
                     print('\t\t\t\tRunning all groups', flush = True)
                     del cmds[0]
-                with mp.get_context('forkserver').Pool(processes = cpus - 1) as pool:
+                with mp.Pool(processes = cpus - 1) as pool:
                     pool.starmap(rnd1_loc2loc_mngr, tqdm(cmds, total = len(cmds), miniters = 1))
                     pool.close()
                     pool.join()
@@ -1792,7 +1792,7 @@ def classify_hlgs(
                     # {ome: {gene: [[set(hgx), clanI]]}}
 
         print('\t\tExtracting clan loci', flush = True)
-        with mp.get_context('forkserver').Pool(processes = cpus) as pool:
+        with mp.Pool(processes = cpus) as pool:
             hash_res = pool.starmap(hash_clan_loci, 
                                     tqdm(((ome, db[ome]['gff3'], clus2extract,
                                           ome2gene2hg[ome], clusplusminus,

--- a/cloci/lib/treecalcs.py
+++ b/cloci/lib/treecalcs.py
@@ -210,7 +210,7 @@ def calc_dists(phylo, cooccur_dict, cpus = 1, omes2dist = {}, func = calc_tmd,
                uniq_sp = False, i2ome = None):
     # multiprocessing calculating only new distances for omes2dist
     if uniq_sp:
-        with mp.get_context('forkserver').Pool(processes = cpus) as pool:
+        with mp.Pool(processes = cpus) as pool:
             results = pool.starmap(
                 calc_tmd_uniq_omes,
                 [(phylo, get_uniq_spp(uniq_sp, x, i2ome), x) \
@@ -220,7 +220,7 @@ def calc_dists(phylo, cooccur_dict, cpus = 1, omes2dist = {}, func = calc_tmd,
             pool.close()
             pool.join()
     else:
-        with mp.get_context('forkserver').Pool(processes = cpus) as pool:
+        with mp.Pool(processes = cpus) as pool:
             results = pool.starmap(
                 func,
                 [(phylo, x,) for x in list(set(cooccur_dict.values())) \


### PR DESCRIPTION
#3 ChildProcessErrors may occur if the multiprocessing context is a fork server. Attempt to resolve this by using the default context.